### PR TITLE
Added pluginloader as a dependency on hekad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ src/github.com/mozilla-services/heka/README.md:
 heka-source: src/github.com/mozilla-services/heka/README.md
 
 bin/hekad: heka-source $(GOBIN)
-	python update_deps.py package_deps.txt
-	cd src && \
+	@python update_deps.py package_deps.txt
+	@cd src && \
 		$(GOCMD) install github.com/mozilla-services/heka/hekad
 
 hekad: bin/hekad

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ src/github.com/mozilla-services/heka/README.md:
 
 heka-source: src/github.com/mozilla-services/heka/README.md
 
-bin/hekad: heka-source $(GOBIN)
+bin/hekad: pluginloader heka-source $(GOBIN)
 	@python update_deps.py package_deps.txt
 	@cd src && \
 		$(GOCMD) install github.com/mozilla-services/heka/hekad


### PR DESCRIPTION
This fixes a problem where the etc/plugin_packages.json is read before the RPMs are built, but not before hekad is compiled.  This would sometimes lead to an RPM being built that did not include heka-mozsvc-plugins, but the unit testsuites would still pass.  
