### PR TITLE
Add the sandbox build to heka-build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+project(heka-build)
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Heka")
+set(CPACK_PACKAGE_VERSION_MAJOR 0)
+set(CPACK_PACKAGE_VERSION_MINOR 2)
+set(CPACK_PACKAGE_VERSION_PATCH 0)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+if(CMAKE_HOST_UNIX)
+	find_library(MATH_LIBRARY m)
+	include(external_lua)
+endif(CMAKE_HOST_UNIX)
+
+include_directories(${CMAKE_BINARY_DIR}/external/include)
+add_subdirectory(src/github.com/mozilla-services/heka/sandbox)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DEPS =
 HERE = $(shell pwd)
 BIN = $(HERE)/bin
 GOBIN = $(HERE)/bin/go
-GOCMD = GOPATH=$(HERE) $(GOBIN)
+GOCMD = LD_LIBRARY_PATH=${BIN} DYLD_LIBRARY_PATH=${BIN} GOPATH=$(HERE) $(GOBIN)
 GOPATH = $GOPATH:$(HERE)
 
 
@@ -19,7 +19,7 @@ clean-src:
 	rm -rf src/*
 
 clean-heka:
-	rm -f bin/hekad
+	rm -f bin/hekad bin/libsandbox.so
 
 clean-all: clean-go clean-src clean-heka
 
@@ -35,6 +35,10 @@ $(GOBIN): build/go
 		./all.bash
 	cp build/go/bin/go $(HERE)/bin/go
 
+sandbox:
+	mkdir -p release
+	cd release && cmake .. && make
+
 src/github.com/mozilla-services/heka/README.md:
 	mkdir -p src/github.com/mozilla-services
 	cd src/github.com/mozilla-services && \
@@ -45,9 +49,9 @@ heka-source: src/github.com/mozilla-services/heka/README.md
 bin/hekad: pluginloader heka-source $(GOBIN)
 	@python update_deps.py package_deps.txt
 	@cd src && \
-		$(GOCMD) install github.com/mozilla-services/heka/hekad
+		$(GOCMD) install -ldflags="-r ./" github.com/mozilla-services/heka/hekad
 
-hekad: bin/hekad
+hekad: sandbox bin/hekad
 
 src/github.com/mozilla-services/heka-mozsvc-plugins/README.md:
 	mkdir -p src/github.com/mozilla-services
@@ -80,6 +84,7 @@ test: gomock gospec
 	$(GOCMD) test -i github.com/mozilla-services/heka/pipeline
 	$(GOCMD) test github.com/mozilla-services/heka/pipeline
 	$(GOCMD) test github.com/mozilla-services/heka/message
+	$(GOCMD) test github.com/mozilla-services/heka/sandbox/lua
 
 test-all: test
 	$(GOCMD) test -i github.com/mozilla-services/heka-mozsvc-plugins

--- a/bin/activate
+++ b/bin/activate
@@ -29,6 +29,14 @@ deactivate () {
         unset _OLD_GOENV_PS1
     fi
 
+    if [ -n "$_OLD_LD_LIBRARY_PATH" ] ; then
+        LD_LIBRARY_PATH="$_OLD_LD_LIBRARY_PATH"
+        export LD_LIBRARY_PATH
+        unset _OLD_LD_LIBRARY_PATH
+    else
+        unset LD_LIBRARY_PATH
+    fi
+
     if [ ! "$1" = "nondestructive" ] ; then
     # Self destruct!
         unset -f deactivate
@@ -64,6 +72,14 @@ if [ -z "$GOENV_DISABLE_PROMPT" ] ; then
     fi
     export PS1
 fi
+
+if [ -n "$LD_LIBRARY_PATH" ] ; then
+    _OLD_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
+    LD_LIBRARY_PATH="$GOPATH/bin:$LD_LIBRARY_PATH"
+else
+    LD_LIBRARY_PATH="$GOPATH/bin"
+fi
+export LD_LIBRARY_PATH
 
 # This should detect bash and zsh, which have a hash command that must
 # be called to get it to forget past commands.  Without forgetting

--- a/cmake/external_lua.cmake
+++ b/cmake/external_lua.cmake
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+include(ExternalProject)
+
+set(_BASE_PATH "${CMAKE_BINARY_DIR}/external")
+set_property(DIRECTORY PROPERTY EP_PREFIX ${_BASE_PATH})
+set(PLATFORM "posix")
+
+if (APPLE)
+    set(PLATFORM "macosx")
+endif(APPLE)
+
+if(UNIX)
+    externalproject_add(
+        lua-5_1_5
+        URL http://www.lua.org/ftp/lua-5.1.5.tar.gz
+        URL_MD5 2e115fe26e435e33b0d5c022e4490567
+        PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/lua-5_1_5.patch
+        CONFIGURE_COMMAND ""
+        BUILD_IN_SOURCE 1
+        BUILD_COMMAND make ${PLATFORM}
+        INSTALL_COMMAND make install INSTALL_TOP="${_BASE_PATH}"
+    )
+endif()
+#todo Windows

--- a/cmake/lua-5_1_5.patch
+++ b/cmake/lua-5_1_5.patch
@@ -1,0 +1,37 @@
+diff -r -u lua-5.1.1/src/ldebug.c lua-5.1.1-hookcount/src/ldebug.c
+--- lua-5.1.1/src/ldebug.c    2005-12-22 17:19:56.000000000 +0100
++++ lua-5.1.1-hookcount/src/ldebug.c    2006-09-10 17:55: 05.000000000 +0200
+@@ -80,6 +80,10 @@
+   return L->basehookcount;
+ }
+ 
++LUA_API int lua_gethookcountremaining (lua_State *L) {
++  return L->hookcount;
++}
++
+ 
+ LUA_API int lua_getstack (lua_State *L, int level, lua_Debug *ar) {
+   int status;
+diff -r -u lua-5.1.1/src/lua.h lua-5.1.1-hookcount/src/lua.h
+--- lua-5.1.1/src/lua.h    2006-06-02 17:34:00.000000000 +0200
++++ lua-5.1.1-hookcount/src/lua.h    2006-09-10 17:55:05.000000000 +0200
+@@ -338,6 +338,7 @@
+ LUA_API lua_Hook lua_gethook (lua_State *L);
+ LUA_API int lua_gethookmask (lua_State *L);
+ LUA_API int lua_gethookcount (lua_State *L);
++LUA_API int lua_gethookcountremaining (lua_State *L);
+ 
+ 
+ struct lua_Debug {
+diff -r -u lua-5.1.1/src/Makefile lua-5.1.1-hookcount/src/Makefile
+--- lua-5_1_1/src/Makefile    2012-02-13 12:41:22.000000000 -0800
++++ lua-5.1.1-hookcount/src/Makefile    2013-02-27 11:48:53.764345692 -0800
+@@ -8,7 +8,7 @@
+ PLAT= none
+ 
+ CC= gcc
+-CFLAGS= -O2 -Wall $(MYCFLAGS)
++CFLAGS= -O2 -Wall -fPIC $(MYCFLAGS)
+ AR= ar rcu
+ RANLIB= ranlib
+ RM= rm -f


### PR DESCRIPTION
CMake is required to pull/patch/build Lua and the sandbox shared
library
