### PR TITLE
patched Makefile to use prepackaged Google binary of go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-APPNAME = hekad 
-DEPS = 
+APPNAME = hekad
+DEPS =
 HERE = $(shell pwd)
 BIN = $(HERE)/bin
 GOBIN = $(HERE)/bin/go
@@ -8,7 +8,7 @@ HGBIN = $(HERE)/pythonVE/bin/hg
 GOCMD = GOPATH=$(HERE) $(GOBIN)
 GOPATH = $GOPATH:$(HERE)
 
-CHECK_GOROOT_CMD = python scripts/check_goroot.py $(HERE)
+CHECK_GOROOT_CMD = python scripts/check_goroot.py $(GOROOT)
 
 ifeq ($(MAKECMDGOALS),test-bench)
 	BENCH = -bench .
@@ -17,7 +17,7 @@ endif
 .PHONY: all build test clean-env clean gospec moz-plugins check_goroot
 .SILENT: test
  
-all: check_goroot build
+all: build
 
 clean-go:
 	rm -rf bin/go build
@@ -56,32 +56,8 @@ docs: $(HERE)/heka-docs $(HERE)/pythonVE/bin/sphinx-build bin/hekad
 		make html SPHINXBUILD=$(HERE)/pythonVE/bin/sphinx-build && \
 		make man SPHINXBUILD=$(HERE)/pythonVE/bin/sphinx-build
 
-build/go:
-	if [ ! -f $(GOROOT)/bin/go ]; \
-	then \
-		if [ ! -f $(HGBIN) ]; \
-		then \
-			$(HERE)/pythonVE/bin/pip install -U Mercurial; \
-		fi && \
-		mkdir -p build && \
-		cd build && \
-			$(HGBIN) clone -u a7bd9a33067b https://code.google.com/p/go; \
-	fi
-
-$(GOBIN): build/go
-	if [ -d $(HERE)/build/go ]; \
-	then \
-		if [ ! -f $(HERE)/build/go/bin/go ]; \
-		then \
-			cd build/go/src && \
-			PATH="$(BIN):$(HERE)/pythonVE/bin:$(PATH)" ./all.bash; \
-		fi && \
-		cp $(HERE)/build/go/bin/go $(HERE)/bin/go && \
-		echo "Using build/go/bin/go bin as go binary"; \
-	else \
-		cp $(GOROOT)/bin/go $(HERE)/bin/go; \
-		echo "Using $(GOROOT)/bin/go bin as go binary"; \
-	fi
+$(GOBIN): FORCE check_goroot
+	cp $(GOROOT)/bin/go $(HERE)/bin/go
 
 sandbox: heka-source
 	mkdir -p release

--- a/scripts/check_goroot.py
+++ b/scripts/check_goroot.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+"""
+Script that checks for reasonable defaults for GOROOT
+"""
+
+import os
+import sys
+
+VALID_GOROOTS = ['/usr/lib/go',
+                 '/usr/local/go',
+                 os.path.normpath('%s/build/go' % sys.argv[1])]
+
+GOROOT = os.getenv('GOROOT', None)
+
+
+def guess_goroot():
+    for p in VALID_GOROOTS:
+        if os.path.exists(p):
+            print "GOROOT should probably be set to this: [%s]" % p
+            break
+
+if not GOROOT:
+    print "GOROOT is not set"
+    guess_goroot()
+    sys.exit(1)
+
+if os.path.exists(GOROOT):
+    go_bin = os.path.join(GOROOT, 'bin/go')
+    if os.path.isfile(go_bin):
+        sys.exit(0)
+
+guess_goroot()
+
+sys.exit(1)

--- a/scripts/check_goroot.py
+++ b/scripts/check_goroot.py
@@ -12,9 +12,9 @@ import os
 import sys
 import re
 import subprocess
+from distutils.version import StrictVersion
 
-
-REV_REGEX = re.compile(r"go version go(\S+) ")
+REV_REGEX = re.compile(r"go version go(\d+\.\d+)")
 
 VALID_GOROOTS = ['/usr/lib/go',
                  '/usr/local/go',
@@ -62,13 +62,8 @@ def version_check(go_bin):
     cmd = '%s version' % go_bin
     version = subprocess.check_output(cmd, shell=True).strip()
     match = REV_REGEX.match(version)
-    groups = match.groups()
-    revision_parts = [int(x) for x in groups[0].split('.')]
-
-    major = revision_parts[0]
-    minor = revision_parts[1]
-
-    return float("%d.%d" % (major, minor)) >= 1.1
+    goversion = match.groups()[0]
+    return StrictVersion(goversion) >= StrictVersion("1.1")
 
 
 if __name__ == "__main__":

--- a/scripts/check_goroot.py
+++ b/scripts/check_goroot.py
@@ -44,15 +44,16 @@ def find_goroot():
                     go_roots['invalid'] = p
 
     if go_roots['valid']:
-        msg = "GOROOT should be set to this: [%s]" % go_roots['valid']
+        msg = "Error: GOROOT should be set to this: [%s]" % go_roots['valid']
     elif go_roots['invalid']:
-        msg = """No valid GOROOT could be found.
+        msg = """Error: No valid GOROOT could be found.
 An old version of Go was found here: [%s]""" % go_roots['invalid']
     else:
-        msg = """Can't find any version of Go installed.
+        msg = """Error: Can't find any version of Go installed.
 Try installing from a package from https://code.google.com/p/go/downloads/"""
 
     print msg
+    return go_roots
 
 def version_check(go_bin):
     """
@@ -72,8 +73,14 @@ def version_check(go_bin):
 
 if __name__ == "__main__":
     if not GOROOT:
-        print "GOROOT is not set"
+        print "Error: GOROOT is not set"
         find_goroot()
         sys.exit(1)
 
-    sys.exit(0)
+    go_bin = os.path.join(GOROOT, 'bin/go')
+    if os.path.isfile(go_bin) and version_check(go_bin):
+        sys.exit(0)
+
+    find_goroot()
+    sys.exit(1)
+

--- a/scripts/check_goroot.py
+++ b/scripts/check_goroot.py
@@ -46,16 +46,8 @@ def find_goroot():
                     go_roots['invalid'] = p
 
     if go_roots['valid']:
-        msg = "Error: GOROOT should be set to this: [%s]" % go_roots['valid']
-    elif go_roots['invalid']:
-        msg = """Error: No valid GOROOT could be found.
-An old version of Go was found here: [%s]""" % go_roots['invalid']
-    else:
-        msg = """Error: Can't find any version of Go installed.
-Try installing from a package from https://code.google.com/p/go/downloads/"""
-
-    print msg
-    return go_roots
+        return go_roots['valid']
+    return ""
 
 def version_check(go_bin):
     """
@@ -70,14 +62,9 @@ def version_check(go_bin):
 
 if __name__ == "__main__":
     if not GOROOT:
-        print "Error: GOROOT is not set"
-        find_goroot()
-        sys.exit(1)
+        GOROOT = find_goroot()
 
     go_bin = os.path.join(GOROOT, 'bin/go')
     if os.path.isfile(go_bin) and version_check(go_bin):
-        sys.exit(0)
-
-    find_goroot()
-    sys.exit(1)
+        print GOROOT
 

--- a/scripts/check_goroot.py
+++ b/scripts/check_goroot.py
@@ -9,16 +9,18 @@ If GOROOT isn't defined try to give a useful suggestion.
 """
 
 import os
+import os.path
 import sys
 import re
 import subprocess
 from distutils.version import StrictVersion
 
 REV_REGEX = re.compile(r"go version go(\d+\.\d+)")
+HERE = os.getcwd()
 
 VALID_GOROOTS = ['/usr/lib/go',
                  '/usr/local/go',
-                 ]
+                 os.path.join(HERE, 'build', 'go')]
 
 if len(sys.argv) > 1:
     hg_go = os.path.normpath('%s/build/go' % sys.argv[1])

--- a/scripts/check_goroot.py
+++ b/scripts/check_goroot.py
@@ -1,35 +1,79 @@
 #!/usr/bin/env python
 
 """
-Script that checks for reasonable defaults for GOROOT
+Script that checks for reasonable defaults for GOROOT.
+
+GOROOT *must* be defined for Heka to compile.
+
+If GOROOT isn't defined try to give a useful suggestion.
 """
 
 import os
 import sys
+import re
+import subprocess
+
+
+REV_REGEX = re.compile(r"go version go(\S+) ")
 
 VALID_GOROOTS = ['/usr/lib/go',
                  '/usr/local/go',
-                 os.path.normpath('%s/build/go' % sys.argv[1])]
+                 ]
+
+if len(sys.argv) > 1:
+    hg_go = os.path.normpath('%s/build/go' % sys.argv[1])
+    VALID_GOROOTS.append(hg_go)
 
 GOROOT = os.getenv('GOROOT', None)
 
 
-def guess_goroot():
+def find_goroot():
+    """
+    Check for possible Go paths using the ordered list of valid go
+    roots
+    """
+    go_roots = {'valid': None, "invalid": None}
     for p in VALID_GOROOTS:
-        if os.path.exists(p):
-            print "GOROOT should probably be set to this: [%s]" % p
-            break
+        go_bin = os.path.join(p, 'bin/go')
+        if os.path.exists(p) and os.path.isfile(go_bin):
+            if version_check(go_bin):
+                if go_roots['valid'] is None:
+                    go_roots['valid'] = p
+            else:
+                if go_roots['invalid'] is None:
+                    go_roots['invalid'] = p
 
-if not GOROOT:
-    print "GOROOT is not set"
-    guess_goroot()
-    sys.exit(1)
+    if go_roots['valid']:
+        msg = "GOROOT should be set to this: [%s]" % go_roots['valid']
+    elif go_roots['invalid']:
+        msg = """No valid GOROOT could be found.
+An old version of Go was found here: [%s]""" % go_roots['invalid']
+    else:
+        msg = """Can't find any version of Go installed.
+Try installing from a package from https://code.google.com/p/go/downloads/"""
 
-if os.path.exists(GOROOT):
-    go_bin = os.path.join(GOROOT, 'bin/go')
-    if os.path.isfile(go_bin):
-        sys.exit(0)
+    print msg
 
-guess_goroot()
+def version_check(go_bin):
+    """
+    Check that we're using at least go 1.1
+    """
+    cmd = '%s version' % go_bin
+    version = subprocess.check_output(cmd, shell=True).strip()
+    match = REV_REGEX.match(version)
+    groups = match.groups()
+    revision_parts = [int(x) for x in groups[0].split('.')]
 
-sys.exit(1)
+    major = revision_parts[0]
+    minor = revision_parts[1]
+
+    return float("%d.%d" % (major, minor)) >= 1.1
+
+
+if __name__ == "__main__":
+    if not GOROOT:
+        print "GOROOT is not set"
+        find_goroot()
+        sys.exit(1)
+
+    sys.exit(0)


### PR DESCRIPTION
Uses go 1.1.1 binary release instead of checking out and building our own binary.

This fixes https://github.com/mozilla-services/heka/issues/180 
