### PR TITLE
runs tests against the hekad config loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,8 @@ gospec: src/github.com/rafrombrc/gospec/src/gospec
 
 test: hekad gomock gospec
 	$(GOCMD) test -i github.com/mozilla-services/heka/pipeline
+	$(GOCMD) test -i github.com/mozilla-services/heka/cmd/hekad
+	$(GOCMD) test -ldflags="-linkmode=external" github.com/mozilla-services/heka/cmd/hekad
 	$(GOCMD) test -ldflags="-linkmode=external" $(BENCH) github.com/mozilla-services/heka/pipeline
 	$(GOCMD) test -ldflags="-linkmode=external" $(BENCH) github.com/mozilla-services/heka/message
 	$(GOCMD) test -ldflags="-linkmode=external" $(BENCH) github.com/mozilla-services/heka/sandbox/lua

--- a/sample/hekad.toml
+++ b/sample/hekad.toml
@@ -1,3 +1,14 @@
+[hekad]
+cpuprof = "/var/log/hekad/cpuprofile.log"
+decoder_poolsize = 10
+max_message_loops = 4
+max_process_inject = 10
+max_timer_inject  = 10
+maxprocs = 10
+memprof = "/var/log/hekad/memprof.log"
+plugin_chansize = 10
+poolsize = 100
+
 [StatsdInput]
 address = "127.0.0.1:8125"
 


### PR DESCRIPTION
This needs to be merged in so that "make test" will run the tests used by https://github.com/mozilla-services/heka/pull/304
